### PR TITLE
Mana regen does not block unconditionnaly for 5 seconds anymore.

### DIFF
--- a/src/relwarb_game.cpp
+++ b/src/relwarb_game.cpp
@@ -123,17 +123,22 @@ bool ManaApply(Skill* skill, Entity* executive, real32 dt)
         if (skill->elapsed >= skill->stepDuration)
         {
             executive->mana += skill->manaRefundPerStep;
-            if (executive->mana > executive->max_mana)
+            if (executive->mana >= executive->max_mana)
             {
                 executive->mana = executive->max_mana;
+                skill->remainingSteps = 0;
             }
+
             skill->elapsed -= skill->stepDuration;
-            skill->remainingSteps -= 1;
             if (skill->remainingSteps == 0)
             {
                 UnsetEntityStatus(executive, EntityStatus_Rooted);
                 skill->remainingCooldown = skill->cooldownDuration;
                 skill->isActive = false;
+            }
+            else
+            {
+                skill->remainingSteps -= 1;
             }
         }
         return true;


### PR DESCRIPTION
Might not be the behaviour wanted, but this really felt weird (and it's less painful when playing for now :D)
There is still one step of blocking when recharge is used when full of mana.